### PR TITLE
Update 17-Testchapter.Rmd

### DIFF
--- a/17-Testchapter.Rmd
+++ b/17-Testchapter.Rmd
@@ -966,21 +966,21 @@ does it work?
     <environment: namespace:rlang>
     ```
 
-1.  __<span style="color:red">Q</span>__: `standardise_call()` doesn't work so well for the following calls.
+1.  __<span style="color:red">Q</span>__: `call_standardise()` doesn't work so well for the following calls.
     Why?
 
     ```{r}
-    lang_standardise(quote(mean(1:10, na.rm = TRUE)))
-    lang_standardise(quote(mean(n = T, 1:10)))
-    lang_standardise(quote(mean(x = 1:10, , TRUE)))
+    call_standardise(quote(mean(1:10, na.rm = TRUE)))
+    call_standardise(quote(mean(n = T, 1:10)))
+    call_standardise(quote(mean(x = 1:10, , TRUE)))
     ```
     
-    __<span style="color:green">A</span>__: The reason is that `mean()` uses S3 dispatch (i.e., `UseMethod`) and therefore does not store its formals on `mean()`, but rather `mean.default()`. For example, `rlang::standardize_call()` can do much better when the S3 dispatch is explicit.
+    __<span style="color:green">A</span>__: The reason for this unexpected behaviour lies in the fact that `mean()` uses S3 dispatch (i.e., `UseMethod`) and therefore does not store its formals on `mean()`, but rather on `mean.default()`. `rlang::call_standardise()` can do much better when the S3 dispatch is explicit.
     
     ```{r}
-    rlang::lang_standardise(quote(mean(1:10, na.rm = TRUE)))
-    rlang::lang_standardise(quote(mean(n = T, 1:10)))
-    rlang::lang_standardise(quote(mean(x = 1:10, , TRUE)))
+    call_standardise(quote(mean.default(1:10, na.rm = TRUE)))
+    call_standardise(quote(mean.default(n = T, 1:10)))
+    call_standardise(quote(mean.default(x = 1:10, , TRUE)))
     ```
 
 1.  __<span style="color:red">Q</span>__: Why does this code not make sense?


### PR DESCRIPTION
- tried to improve wording
- replaced `lang_standardise` with `call_standardise` (will be done in the book also, as `lang_standardise` is soft deprecated. (PR for AdvR was already accepted, https://github.com/hadley/adv-r/pull/973)
- removed `rlang::`
- added `.default` tp `mean`