### PR TITLE
broom::tidy() microbenchmark object would cause error

### DIFF
--- a/2-17-Performance.Rmd
+++ b/2-17-Performance.Rmd
@@ -126,7 +126,7 @@
       control = list(warmup = 1000)
       ))
 
-    mb_prom_median <- broom::tidy(mb_prom)[2,]$median
+    mb_prom_median <- summary(mb_prom)$median
     ```
     
    This lets us calculate, that ~`r round(420 / mb_prom_median, 4) * 100`% of the median run time are caused by the extra arguments.


### PR DESCRIPTION
microbenchmark   1.4-6    2018-10-18 [1] CRAN (R 3.5.1)
broom                    0.5.1    2018-12-05 [1] CRAN (R 3.5.1)