### PR TITLE
fix exercise 3 of "10.2 Factory fundamentals"

### DIFF
--- a/2-09-Function_factories.Rmd
+++ b/2-09-Function_factories.Rmd
@@ -49,7 +49,7 @@ library(rlang)
    
     ```{r}
     pick <- function(i) {
-      force(x)
+      force(i)
     
       function(x) x[[i]]
     }


### PR DESCRIPTION
```
> pick <- function(i) {
+   force(x)
+ 
+   function(x) x[[i]]
+ }
> identical(x[[1]], pick(1)(x))
Error in identical(x[[1]], pick(1)(x)) : object 'x' not found
```