### PR TITLE
Corrections on exercise 10.5.1

### DIFF
--- a/2-10-Function_factories.Rmd
+++ b/2-10-Function_factories.Rmd
@@ -269,7 +269,7 @@ source("common.R")
    (d) `f(z)`.
    (e) It depends.
 
-   __<span style="color:green">A</span>__: e: It depends ;-). Typically (b) (`f(x$z)`) is equivalent. However, if `x` is bound in the current environment, also d (`f(z)`) is equivalent.
+   __<span style="color:green">A</span>__: e: It depends ;-). Typically (c) (`x$f(z)`) is equivalent. However, if `x` is bound in the current environment, also d (`f(z)`) is equivalent.
 
 2. __<span style="color:red">Q</span>__: Compare and contrast the effects of `env_bind()` vs. `attach()` for the following code.
    


### PR DESCRIPTION
There was a mistake in the exercise 10.5.1, since ``x$f(z)`` should be correct and not ``f(x$z)``.

One can double check the answer using the functions introduced in the textbook: 
 
```
names <- list(
  square = 2, 
  cube = 3, 
  root = 1/2, 
  cuberoot = 1/3, 
  reciprocal = -1
)
funs <- purrr::map(names, power1)
```

``with(funs, square(2))`` corresponds to ``x$f(z)`` and not to ``f(x$z)``.