### PR TITLE
Fix some small duplicates

### DIFF
--- a/2-18-Expressions.Rmd
+++ b/2-18-Expressions.Rmd
@@ -10,7 +10,6 @@ To capture and compute on expressions, and to visualise them, we will load the r
 ```{r}
 library(rlang)
 library(lobstr)
-library(rlang)
 ```
 
 ## Abstract syntax trees

--- a/2-19-Quasiquotation.Rmd
+++ b/2-19-Quasiquotation.Rmd
@@ -11,10 +11,6 @@ To further compute on the language, we mainly use the rlang package in this sect
 library(rlang)
 ```
 
-```{r}
-library(rlang)
-```
-
 ## Motivation
 
 1. __<span style="color:red">Q</span>__: For each function in the following base R code, identify which arguments are quoted and which are evaluated.


### PR DESCRIPTION
Thank you for your awesome work. 

- `library(rlang)` is duplicated for chapter 18 and 19. I removed them.

"I assign the copyright of this contribution to Malte Grosser and Henning Bumann"