### PR TITLE
Update 19_Quasiquotation.Rmd

### DIFF
--- a/19_Quasiquotation.Rmd
+++ b/19_Quasiquotation.Rmd
@@ -270,7 +270,7 @@ expr(!!xy / !!yz)                    # (1)
 
 expr(-(!!xz)^(!!yz))                 # (2)
 
-expr(!!xy + !!yz - !!xz)             # (3)
+expr(((!!xy)) + !!yz-!!xy)           # (3)
 
 expr(atan2(!!xy, !!yz))              # (4)
 


### PR DESCRIPTION
Changed solution to "Unquoting" exercise 1 (3). With this solution also parentheses around the first x+y are part of the expression.