### PR TITLE
Update 25_Rewriting_R_code_in_Cpp.Rmd - overwrite autolinks to R function definition

### DIFF
--- a/25_Rewriting_R_code_in_Cpp.Rmd
+++ b/25_Rewriting_R_code_in_Cpp.Rmd
@@ -421,9 +421,9 @@ double medianC(NumericVector x) {
 }
 ```
 
-__[Q2]{.Q}__: `%in%` using `unordered_set` and the `find()` or `count()` methods.
+__[Q2]{.Q}__: `%in%` using `unordered_set` and the [`find()`](https://en.cppreference.com/w/cpp/container/unordered_set/find) or [`count()`](https://en.cppreference.com/w/cpp/container/unordered_set/count) methods.
 
-__[A]{.solved}__: We use the `find()` method and loop through the `unordered_set` until we find a match or have scanned the entire set.
+__[A]{.solved}__: We use the [`find()`](https://en.cppreference.com/w/cpp/container/unordered_set/find) method and loop through the `unordered_set` until we find a match or have scanned the entire set.
 
 ```{Rcpp, eval = FALSE}
 #include <Rcpp.h>


### PR DESCRIPTION
The `find()` and `count()` function was linking to the R function definition, it should in this case link to the corresponding C++ unordered set functions.

"I assign the copyright of this contribution to Malte Grosser and Henning Bumann".

